### PR TITLE
fix interval selection when keys are intervals

### DIFF
--- a/src/selectors.jl
+++ b/src/selectors.jl
@@ -12,6 +12,13 @@ findindex(int::Interval, r::AbstractVector) =
 findindex(int::Interval, r::AbstractRange{T}) where {T<:Union{Number,Char}} =
     findall(in(int), r)
 
+# find interval in a vector of intervals: same as generic findindex in lookup.jl
+function findindex(int::Interval, r::AbstractVector{<:Interval})
+    i = findfirst(isequal(int), r)
+    i === nothing && throw(ArgumentError("could not find key $(repr(a)) in vector $r"))
+    i
+end
+
 # Since that is now efficient for ranges, comparisons can go there:
 
 findindex(eq::Base.Fix2{typeof(<=)}, r::AbstractRange{T}) where {T<:Union{Number,Char}} =

--- a/test/_basic.jl
+++ b/test/_basic.jl
@@ -77,6 +77,10 @@ end
     @test V(Near(0.12)) == V(0.1) == V[2]
     @test V(Interval(0.1, 0.3)) == V[2:4]
 
+    VI = KeyedArray([1, 2, 3], xs=[Interval(1, 2), Interval(2, 3), Interval(1, 3)])
+    @test VI(Interval(1, 3)) == VI[3]
+    @test VI([Interval(1, 2), Interval(1, 3)]) == VI[[1, 3]]
+
     @test V(Index[1]) == V[1]
     @test V(Index[2:3]) == V[2:3]
     @test V(Index[end]) == V[end]


### PR DESCRIPTION
it wasn't possible to simply index by key if keys are intervals themlselves