### PR TITLE
remove dedicated findindex method for ranges, increasing performance

### DIFF
--- a/src/lookup.jl
+++ b/src/lookup.jl
@@ -88,13 +88,6 @@ findindex(a::Union{AbstractArray, Base.Generator}, r::AbstractArray) =
 
 findindex(f::Function, r::AbstractArray) = findall(f, r)
 
-# Faster than Base.findfirst(==(i), 1:10) etc:
-# Now also https://github.com/JuliaLang/julia/pull/35256
-
-findindex(i::Int, r::Base.OneTo{Int}) = 1 <= i <= r.stop ? i : nothing
-
-findindex(i::Int, r::AbstractUnitRange) = first(r) <= i <= last(r) ? 1+Int(i - first(r)) : nothing
-
 findindex(i::AbstractUnitRange{T}, r::AbstractUnitRange{T}) where {T} = findall(∈(i), r)
 
 # Faster than Base.findall(==(i), 1:10) etc,


### PR DESCRIPTION
I guess they were needed before, but not anymore since https://github.com/JuliaLang/julia/pull/35256.
The `nothing` branch was leading to some instability as well, so this removal actually improves performance:
```julia
julia> A = KeyedArray(rand(1000), (-499:500,));

julia> f(A) = sum(i -> (@inbounds A(i)), -499:500)
f (generic function with 1 method)

# before:
julia> @b f($A)
19.291 μs (1489 allocs: 23.266 KiB)

# after:
julia> @b f($A)
836.207 ns
```
Does this look reasonable @mcabbott?
Maybe an even faster implementation is possible?