### PR TITLE
push! and append! use axiskey of NaN instead of n+1 when no natural continuation exists

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AxisKeys"
 uuid = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
 license = "MIT"
-version = "0.2.17"
+version = "0.2.18"
 
 [deps]
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"

--- a/src/push.jl
+++ b/src/push.jl
@@ -39,8 +39,8 @@ end
 extend_one!!(r::Base.OneTo) = Base.OneTo(last(r)+1)
 extend_one!!(r::UnitRange{Int}) = UnitRange(r.start, r.stop + 1)
 extend_one!!(r::StepRange{<:Any,Int}) = StepRange(r.start, r.step, r.stop + r.step)
-extend_one!!(r::Vector{<:Number}) = push!(r, length(r)+1)
-extend_one!!(r::AbstractVector) = vcat(r, length(r)+1)
+extend_one!!(r::Vector{<:Number}) = push!(r, eltype(r)(NaN))
+extend_one!!(r::AbstractVector{<:Number}) = vcat(r, eltype(r)(NaN))
 
 shorten_one!!(r::Base.OneTo) = Base.OneTo(last(r)-1)
 shorten_one!!(r::Vector) = pop!(r)
@@ -76,8 +76,8 @@ end
 extend_by!!(r::Base.OneTo, n::Int) = Base.OneTo(last(r)+n)
 extend_by!!(r::UnitRange{Int}, n::Int) = UnitRange(r.start, r.stop + n)
 extend_by!!(r::StepRange{<:Any,Int}, n::Int) = StepRange(r.start, r.step, r.stop + n * r.step)
-extend_by!!(r::Vector{<:Number}, n::Int) = append!(r, length(r)+1 : length(r)+n+1)
-extend_by!!(r::AbstractVector, n::Int) = vcat(r, length(r)+1 : length(r)+n+1)
+extend_by!!(r::Vector{<:Number}, n::Int) = append!(r, (eltype(r)(NaN) for _ in 1:n))
+extend_by!!(r::AbstractVector, n::Int) = vcat(r, (eltype(r)(NaN) for _ in 1:n))
 
 append!!(r::Vector, s::AbstractVector) = append!(r,s)
 append!!(r::AbstractVector, s::AbstractVector) = (extend_by!!(r, length(s)); vcat(r,s))

--- a/test/_basic.jl
+++ b/test/_basic.jl
@@ -1,4 +1,4 @@
-using Test, AxisKeys
+using Test, AxisKeys, Unitful
 
 @testset "basics" begin
 
@@ -321,6 +321,21 @@ end
     V2 = KeyedArray(rand(3), Base.OneTo(3))
     @test axiskeys(push!(V2, 0)) === (Base.OneTo(4),)
     @test axiskeys(append!(V2, [7,7])) === (Base.OneTo(6),)
+
+    V3 = KeyedArray([3,5,7], [1, 5, 15])
+    # no natural value for integer axiskey:
+    @test_throws Exception push!(V3, 11)
+    @test_throws Exception append!(V3, [20, 25])
+
+    V4 = KeyedArray([3,5,7], [0.1, 0.5, 1.5])
+    push!(V4, 11)
+    append!(V4, [13, 17])
+    @test isequal(axiskeys(V4), ([0.1, 0.5, 1.5, NaN, NaN, NaN],))
+
+    V5 = KeyedArray([3,5,7], [0.1, 0.5, 1.5]u"m")
+    push!(V5, 11)
+    append!(V5, [13, 17])
+    @test isequal(axiskeys(V5), ([0.1, 0.5, 1.5, NaN, NaN, NaN]u"m",))
 
     AxisKeys.nameouter() || # fails with nda(ka(...))
         @test axiskeys(append!(V2, V),1) == [1, 2, 3, 4, 5, 6, 10, 20, 30, 40]


### PR DESCRIPTION
Used length(A) + 1 before, which doesn't generally make sense (and completely fails for axiskeys with units).
Swithch to (properly-typed) NaN, making it clear that there's no natural axiskey value.

This regime wasn't tested at all: no tests are changed or removed, only new ones added.