### PR TITLE
Fix cat function for KeyedArrays with unnamed dimensions

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -138,7 +138,7 @@ for (T, S) in [ (:KeyedArray, :KeyedArray),
             α, β
         else
             α = val_strip(dims)
-            β = cat(keyless(A), keyless(B), keyless.(Cs)...; dims=numerical_dims)
+            β = cat(keyless(A), keyless(B), keyless.(Cs)...; dims=dims)
             α, β
         end
         new_keys = ntuple(ndims(data)) do d

--- a/test/_functions.jl
+++ b/test/_functions.jl
@@ -6,6 +6,7 @@ MN = NamedDimsArray(M.data.data, r='a':'c', c=2:5)
 V = wrapdims(rand(1:99, 10), v=10:10:100)
 VN = NamedDimsArray(V.data.data, v=10:10:100)
 A3 = wrapdims(rand(Int8, 3,4,2), r='a':'c', c=2:5, p=[10.0, 20.0])
+MND = wrapdims(rand(Int8, 2, 3), 11.0:12.0, [:a, :b, :c])
 
 @testset "dims" begin
 
@@ -230,6 +231,13 @@ end
 
     @test dimnames(cat(M; dims=3)) == (:r, :c, :_)
     @test axiskeys(cat(M; dims=3)) == ('a':1:'c', 2:5, Base.OneTo(1))
+
+    @test axiskeys(vcat(MND,MND)) == ([11.0, 12.0, 11.0, 12.0], [:a, :b, :c])
+    @test axiskeys(hcat(MND,MND)) == (11.0:1.0:12.0, [:a, :b, :c, :a, :b, :c])
+    @test dimnames(vcat(MND,MND)) == (:_, :_)
+    @test dimnames(hcat(MND,MND)) == (:_, :_)
+    @test cat(MND,MND; dims=1) == vcat(MND,MND)
+    @test cat(MND,MND; dims=2) == hcat(MND,MND)
 end
 @testset "matmul" begin
 


### PR DESCRIPTION
Fixes concatenating `KeyedArray`s with `cat` when there are unnamed dimensions.

```julia
julia> A = wrapdims(rand(2,3), 11.0:12.0, [:a, :b, :c])
2-dimensional KeyedArray(...) with keys:
↓   2-element StepRangeLen{Float64,...}
→   3-element Vector{Symbol}
And data, 2×3 Matrix{Float64}:
         (:a)       (:b)       (:c)
 (11.0)   0.415957   0.752289   0.77297
 (12.0)   0.842102   0.495482   0.930051

julia> vcat(A, A)
2-dimensional KeyedArray(...) with keys:
↓   4-element Vector{Float64}
→   3-element Vector{Symbol}
And data, 4×3 Matrix{Float64}:
         (:a)       (:b)       (:c)
 (11.0)   0.415957   0.752289   0.77297
 (12.0)   0.842102   0.495482   0.930051
 (11.0)   0.415957   0.752289   0.77297
 (12.0)   0.842102   0.495482   0.930051

julia> cat(A, A; dims=1)
ERROR: UndefVarError: `numerical_dims` not defined in local scope
Suggestion: check for an assignment to a local variable that shadows a global of the same name.
Stacktrace:
 [1] cat(::KeyedArray{Float64, 2, Matrix{…}, Tuple{…}}, ::KeyedArray{Float64, 2, Matrix{…}, Tuple{…}}; dims::Int64)
   @ AxisKeys ~/.julia/packages/AxisKeys/a6h2b/src/functions.jl:141
 [2] top-level scope
   @ REPL[4]:1
 [3] top-level scope
   @ REPL:1
Some type information was truncated. Use `show(err)` to see complete types.
```

Found when looking for `Core.Box` allocations using [this code](https://github.com/JuliaLang/julia/blob/1a436095dc920c7f4a5b0ded0323a256f09c4b5a/stdlib/Test/src/Test.jl#L2570).

Added additional tests as well.

